### PR TITLE
feat/addscore-command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BOT_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Generated output
 dist/
+prisma/migrations/
 
 # Packages
 node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
                 "@discordjs/core": "^0.6.0",
                 "@discordjs/rest": "^1.7.1",
                 "@discordjs/ws": "^0.8.3",
-                "dotenv": "^16.3.1"
+                "@prisma/client": "^5.0.0",
+                "dotenv": "^16.3.1",
+                "prisma": "^5.0.0"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -292,6 +294,37 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@prisma/client": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
+            "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+            },
+            "engines": {
+                "node": ">=16.13"
+            },
+            "peerDependencies": {
+                "prisma": "*"
+            },
+            "peerDependenciesMeta": {
+                "prisma": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@prisma/engines": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
+            "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+            "hasInstallScript": true
+        },
+        "node_modules/@prisma/engines-version": {
+            "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+            "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+        },
         "node_modules/@sapphire/async-queue": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
@@ -322,9 +355,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.4.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg=="
+            "version": "20.4.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
+            "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
         },
         "node_modules/@types/semver": {
             "version": "7.5.0",
@@ -1699,6 +1732,21 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prisma": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
+            "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@prisma/engines": "5.0.0"
+            },
+            "bin": {
+                "prisma": "build/index.js"
+            },
+            "engines": {
+                "node": ">=16.13"
             }
         },
         "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
+                "@discordjs/core": "^0.6.0",
+                "@discordjs/rest": "^1.7.1",
+                "@discordjs/ws": "^0.8.3",
                 "dotenv": "^16.3.1"
             },
             "devDependencies": {
@@ -31,6 +34,85 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/@discordjs/collection": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz",
+            "integrity": "sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/core": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/core/-/core-0.6.0.tgz",
+            "integrity": "sha512-Z8utdvCtT+ukOL38AHmGjwVYc8WR7NpTVAKINX+HVBq870GcUMFCQl7nJT+whnUdo+NbnC96LmP11+onEhdL6A==",
+            "dependencies": {
+                "@discordjs/rest": "^1.7.1",
+                "@discordjs/util": "^0.3.0",
+                "@discordjs/ws": "^0.8.2",
+                "@sapphire/snowflake": "^3.4.2",
+                "@vladfrangu/async_event_emitter": "^2.2.1",
+                "discord-api-types": "^0.37.41"
+            },
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/rest": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
+            "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+            "dependencies": {
+                "@discordjs/collection": "^1.5.1",
+                "@discordjs/util": "^0.3.0",
+                "@sapphire/async-queue": "^1.5.0",
+                "@sapphire/snowflake": "^3.4.2",
+                "discord-api-types": "^0.37.41",
+                "file-type": "^18.3.0",
+                "tslib": "^2.5.0",
+                "undici": "^5.22.0"
+            },
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/tslib": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        },
+        "node_modules/@discordjs/util": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
+            "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/ws": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz",
+            "integrity": "sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==",
+            "dependencies": {
+                "@discordjs/collection": "^1.5.1",
+                "@discordjs/rest": "^1.7.1",
+                "@discordjs/util": "^0.3.1",
+                "@sapphire/async-queue": "^1.5.0",
+                "@types/ws": "^8.5.4",
+                "@vladfrangu/async_event_emitter": "^2.2.1",
+                "discord-api-types": "^0.37.41",
+                "tslib": "^2.5.0",
+                "ws": "^8.13.0"
+            },
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/@discordjs/ws/node_modules/tslib": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -210,17 +292,53 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@sapphire/async-queue": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+            "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@sapphire/snowflake": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+            "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.12",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
             "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
             "dev": true
         },
+        "node_modules/@types/node": {
+            "version": "20.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg=="
+        },
         "node_modules/@types/semver": {
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
             "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
             "dev": true
+        },
+        "node_modules/@types/ws": {
+            "version": "8.5.5",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+            "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.61.0",
@@ -410,6 +528,15 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@vladfrangu/async_event_emitter": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
+            "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -514,6 +641,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -611,6 +749,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/discord-api-types": {
+            "version": "0.37.48",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.48.tgz",
+            "integrity": "sha512-vu2NQJD7SZRjpKDC2DPNsxTz34KS53OrotA+LGRW6mcyT55Hjqu66aRrouzjYhea7tllL9I7rvWVX7bg3aT2AQ=="
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -909,6 +1052,22 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/file-type": {
+            "version": "18.5.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
+            "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
+            "dependencies": {
+                "readable-web-to-node-stream": "^3.0.2",
+                "strtok3": "^7.0.0",
+                "token-types": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1121,6 +1280,25 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/ignore": {
             "version": "5.2.4",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1168,8 +1346,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -1491,6 +1668,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/peek-readable": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+            "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1540,6 +1729,34 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/readable-web-to-node-stream": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+            "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+            "dependencies": {
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -1600,6 +1817,25 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/semver": {
             "version": "7.5.4",
@@ -1668,6 +1904,22 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/string-width": {
@@ -1772,6 +2024,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strtok3": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+            "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0",
+                "peek-readable": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1800,6 +2068,22 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/token-types": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+            "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/tslib": {
@@ -1860,6 +2144,17 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici": {
+            "version": "5.22.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+            "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+            "dependencies": {
+                "busboy": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1868,6 +2163,11 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -1983,6 +2283,26 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/ws": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
         "clean-build": "npm run clean && npm run build",
         "dev": "npm run clean-build && npm run start",
         "lint": "npx eslint \"src/*\" --fix --ext .ts",
-        "prod": "npm run clean-build && npm run start:prod",
-        "start": "node -r dotenv/config dist/index.js",
-        "start:prod": "node -r dotenv/config dist/index.js"
+        "prod": "npm run clean-build && npm run start",
+        "start": "node -r dotenv/config dist/index.js"
     },
     "type": "module",
     "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
     "author": "Toronto Riichi Club",
     "dependencies": {
-        "dotenv": "^16.3.1"
+        "@discordjs/core": "^0.6.0",
+        "@discordjs/rest": "^1.7.1",
+        "@discordjs/ws": "^0.8.3",
+        "@prisma/client": "^5.0.0",
+        "dotenv": "^16.3.1",
+        "prisma": "^5.0.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.61.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
         "node": ">=18.1.6",
         "npm": ">=9.8.0"
     },
+    "imports": {
+        "#events": "./dist/events/index.js",
+        "#interactions": "./dist/interactions/index.js",
+        "#structs": "./dist/structs/index.js",
+        "#types/*": "./dist/types/*.d.ts",
+        "#utility": "./dist/utility/index.js"
+    },
     "license": "MIT",
     "main": "dist/index.js",
     "name": "toribot",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,49 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+enum GameLocation {
+    PEEL     @map("PEEL")
+    TORONTO  @map("TORONTO")
+    WATERLOO @map("WATERLOO")
+    YORK     @map("YORK")
+}
+
+enum GameType {
+    HANCHAN @map("HANCHAN")
+}
+
+model Game {
+    id               Int          @id @default(autoincrement())
+    submitter        String
+    playerOne        String       @map("player_one")
+    playerTwo        String       @map("player_two")
+    playerThree      String       @map("player_three")
+    playerFour       String       @map("player_four")
+    playerOneScore   Int          @map("player_one_score")
+    playerTwoScore   Int          @map("player_two_score")
+    playerThreeScore Int          @map("player_three_score")
+    playerFourScore  Int          @map("player_four_score")
+    leftoverPoints   Int          @map("leftover_points")
+    location         GameLocation
+    type             GameType     @default(HANCHAN)
+    createdAt        DateTime     @default(now()) @map("created_at") @db.Timestamptz()
+    updatedAt        DateTime?    @updatedAt @map("updated_at") @db.Timestamptz()
+
+    @@map("game")
+}
+
+model Player {
+    username String  @unique
+    userId   BigInt? @map("user_id")
+
+    @@map("player")
+}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,9 @@
+import { handleInteractionCreate } from './interactionCreate.js'
+import { handleReady } from './ready.js'
+import type { ToribotClient } from '#structs'
+import { GatewayDispatchEvents } from '@discordjs/core'
+
+export async function handleEvents(client: ToribotClient) {
+    client.on(GatewayDispatchEvents.InteractionCreate, async payload => await handleInteractionCreate(client, payload))
+    client.on(GatewayDispatchEvents.Ready, async payload => await handleReady(client, payload))
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -57,6 +57,7 @@ export async function handleInteractionCreate(client: ToribotClient, payload: Wi
         case InteractionType.ApplicationCommandAutocomplete: {
             const interaction = new ChatInputCommandInteraction({
                 data: data as APIChatInputApplicationCommandInteractionData,
+                guildId,
                 username: member.user.username,
                 ...baseOptions
             })

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,0 +1,100 @@
+import { commands, modals } from '#interactions'
+import {
+    BaseInteraction,
+    ChatInputCommandInteraction,
+    ModalInteraction,
+    type ToribotClient,
+} from '#structs'
+import {
+    type APIChatInputApplicationCommandInteractionData,
+    type APIEmbed,
+    type GatewayInteractionCreateDispatchData,
+    MessageFlags,
+    PermissionFlagsBits,
+    InteractionType,
+    type WithIntrinsicProps,
+} from '@discordjs/core'
+
+export async function handleInteractionCreate(client: ToribotClient, payload: WithIntrinsicProps<GatewayInteractionCreateDispatchData>) {
+    const {
+        application_id: applicationId,
+        app_permissions,
+        data,
+        guild_id: guildId,
+        id,
+        member,
+        token,
+        type,
+    } = payload.data
+    const baseOptions = { applicationId, id, rest: client.rest, token }
+    const baseInteraction = new BaseInteraction(baseOptions)
+    const embed: Partial<APIEmbed> = { color: 0xF8F8FF }
+
+    if (!guildId) {
+        embed.description = 'toribot only works in guilds.'
+
+        await baseInteraction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+        return
+    }
+
+    const permissions = BigInt(app_permissions)
+    const missingPermissions = []
+
+    if ((permissions & PermissionFlagsBits.SendMessages) !== PermissionFlagsBits.SendMessages)
+        missingPermissions.push("**Send Messages**")
+    if ((permissions & PermissionFlagsBits.EmbedLinks) !== PermissionFlagsBits.EmbedLinks)
+        missingPermissions.push("**Embed Links**")
+
+    if (missingPermissions.length) {
+        embed.description = `toribot requires the ${ new Intl.ListFormat().format(missingPermissions) } ${ missingPermissions.length === 1 ? 'permission': 'permissions' } in order to run this command.`
+
+        await baseInteraction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+        return
+    }
+
+    switch (type) {
+        case InteractionType.ApplicationCommand:
+        case InteractionType.ApplicationCommandAutocomplete: {
+            const interaction = new ChatInputCommandInteraction({
+                data: data as APIChatInputApplicationCommandInteractionData,
+                username: member.user.username,
+                ...baseOptions
+            })
+            const { name } = interaction.data
+            const command = commands.get(name)
+
+            if (!command) {
+                embed.description = `I have received an unknown command with the name "${ name }".`
+
+                await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+            } else
+                await command.run(client, interaction)
+
+            break
+        }
+        case InteractionType.ModalSubmit: {
+            const interaction = new ModalInteraction({
+                data,
+                username: member.user.username,
+                ...baseOptions
+            })
+            const key = interaction.data.custom_id.split(':')[0]
+            const modal = modals.get(key)
+
+            if (!modal) {
+                embed.description = `I have received an unknown modal with the name "${ key }".`
+
+                await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+            } else
+                await modal.handle(client, interaction)
+
+            break
+        }
+        default: {
+            embed.description = 'I have received an unknown interaction.'
+
+            await baseInteraction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+            break
+        }
+    }
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,12 +1,8 @@
-import { commands } from '#interactions'
 import type { ToribotClient } from '#structs'
 import type { GatewayReadyDispatchData, WithIntrinsicProps } from '@discordjs/core'
 
 export async function handleReady(client: ToribotClient, payload: WithIntrinsicProps<GatewayReadyDispatchData>) {
     const { user } = payload.data
-    const commandJson = [...commands.values()].map(command => command.getCommand())
-
-    await client.api.applicationCommands.bulkOverwriteGlobalCommands(user.id, commandJson)
 
     console.log(`${ user.username }#${ user.discriminator } is online!`)
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,0 +1,12 @@
+import { commands } from '#interactions'
+import type { ToribotClient } from '#structs'
+import type { GatewayReadyDispatchData, WithIntrinsicProps } from '@discordjs/core'
+
+export async function handleReady(client: ToribotClient, payload: WithIntrinsicProps<GatewayReadyDispatchData>) {
+    const { user } = payload.data
+    const commandJson = [...commands.values()].map(command => command.getCommand())
+
+    await client.api.applicationCommands.bulkOverwriteGlobalCommands(user.id, commandJson)
+
+    console.log(`${ user.username }#${ user.discriminator } is online!`)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
-const hello = 'world'
+import { commands } from '#interactions'
+import { ToribotClient } from '#structs'
+import { handleEvents } from '#events'
+
+const client = new ToribotClient()
+const { id } = await client.api.users.getCurrent()
+const commandJson = [...commands.values()].map(command => command.getCommand())
+
+await client.api.applicationCommands.bulkOverwriteGlobalCommands(id, commandJson)
+await handleEvents(client)
+await client.login()

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ import { handleEvents } from '#events'
 
 const client = new ToribotClient()
 const { id } = await client.api.users.getCurrent()
+const players = await client.database.players.getPlayers()
 const commandJson = [...commands.values()].map(command => command.getCommand())
+
+for (const player of players)
+    client.cache.players.insert(player.username, player.userId)
 
 await client.api.applicationCommands.bulkOverwriteGlobalCommands(id, commandJson)
 await handleEvents(client)

--- a/src/interactions/command/addscore.ts
+++ b/src/interactions/command/addscore.ts
@@ -99,7 +99,7 @@ export const AddScoreCommand: ChatInputCommand = {
             { value: playerFour },
             { value: location },
             { value: type = GameType.HANCHAN } = {}
-        ] = interaction.data.options as APIApplicationCommandInteractionDataStringOption[]
+        ] = interaction.options as APIApplicationCommandInteractionDataStringOption[]
         const uniquePlayers = [...new Set([playerOne, playerTwo, playerThree, playerFour])]
         const embed: Partial<APIEmbed> = { color: 0xF8F8FF }
 

--- a/src/interactions/command/addscore.ts
+++ b/src/interactions/command/addscore.ts
@@ -1,0 +1,175 @@
+import type { ChatInputCommandInteraction, ToribotClient } from '#structs'
+import type { ChatInputCommand } from '#types/interaction'
+import {
+    type APIActionRowComponent,
+    type APIApplicationCommandInteractionDataStringOption,
+    type APIApplicationCommandOptionChoice,
+    type APIEmbed,
+    type APIModalInteractionResponseCallbackData,
+    type APITextInputComponent,
+    ApplicationCommandOptionType,
+    ComponentType,
+    MessageFlags,
+    TextInputStyle,
+    type RESTPostAPIApplicationCommandsJSONBody,
+} from '@discordjs/core'
+import { GameLocation, GameType } from '@prisma/client'
+
+export const AddScoreCommand: ChatInputCommand = {
+    getCommand(): RESTPostAPIApplicationCommandsJSONBody {
+        return {
+            description: 'Record an in-person game',
+            name: 'addscore',
+            options: [
+                {
+                    autocomplete: true,
+                    description: 'Player 1',
+                    name: 'player-one',
+                    required: true,
+                    type: ApplicationCommandOptionType.String
+                },
+                {
+                    autocomplete: true,
+                    description: 'Player 2',
+                    name: 'player-two',
+                    required: true,
+                    type: ApplicationCommandOptionType.String
+                },
+                {
+                    autocomplete: true,
+                    description: 'Player 3',
+                    name: 'player-three',
+                    required: true,
+                    type: ApplicationCommandOptionType.String
+                },
+                {
+                    autocomplete: true,
+                    description: 'Player 4',
+                    name: 'player-four',
+                    required: true,
+                    type: ApplicationCommandOptionType.String
+                },
+                {
+                    choices: [
+                        { name: 'Peel', value: GameLocation.PEEL },
+                        { name: 'Toronto', value: GameLocation.TORONTO },
+                        { name: 'Waterloo', value: GameLocation.WATERLOO },
+                        { name: 'York', value: GameLocation.YORK }
+                    ],
+                    description: 'The game location',
+                    name: 'location',
+                    required: true,
+                    type: ApplicationCommandOptionType.String
+                },
+                {
+                    choices: [
+                        { name: 'Hanchan', value: GameType.HANCHAN }
+                    ],
+                    description: 'The game type',
+                    name: 'type',
+                    type: ApplicationCommandOptionType.String
+                }
+            ]
+        }
+    },
+    async run(client: ToribotClient, interaction: ChatInputCommandInteraction): Promise<void> {
+        const focusedOption = interaction.getFocusedOption()
+
+        if (focusedOption) {
+            const { value } = focusedOption
+            const valueSanitized = value.toString().toLowerCase()
+            const choices: APIApplicationCommandOptionChoice<string>[] = []
+
+            for (const [username, userId] of client.cache.players.entries()) {
+                if (username.includes(valueSanitized) || userId?.toString().includes(valueSanitized))
+                    choices.push({ name: userId ? `@${username}` : username, value: username })
+                if (choices.length >= 25)
+                    break
+            }
+
+            choices.sort((a, b) => a.name.localeCompare(b.name))
+
+            return interaction.autocomplete(choices)
+        }
+
+        const [
+            { value: playerOne },
+            { value: playerTwo },
+            { value: playerThree },
+            { value: playerFour },
+            { value: location },
+            { value: type = GameType.HANCHAN } = {}
+        ] = interaction.data.options as APIApplicationCommandInteractionDataStringOption[]
+        const uniquePlayers = [...new Set([playerOne, playerTwo, playerThree, playerFour])]
+        const embed: Partial<APIEmbed> = { color: 0xF8F8FF }
+
+        if (uniquePlayers.length !== 4) {
+            embed.description = 'Please provide 4 unique player usernames.'
+
+            await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+
+            return
+        }
+
+        const areAllUsernamesValid = uniquePlayers.every(username => /^[A-Za-z0-9_\.]*$/g.test(username))
+
+        if (!areAllUsernamesValid) {
+            embed.description = 'Please ensure that all users consist of **only** letters, numbers, underscores, and periods.'
+
+            await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral })
+
+            return
+        }
+
+        for (const [index, username] of uniquePlayers.entries()) {
+            if (client.cache.players.get(username))
+                continue
+
+            const searchResult = await client.api.guilds.searchForMembers(interaction.guildId, { query: username })
+            const user = searchResult?.[0]?.user
+            const u = user?.username ?? username
+            const i = user ? BigInt(user.id) : null
+
+            await client.database.players.insertPlayer(u, i)
+
+            client.cache.players.insert(u, i)
+            uniquePlayers[index] = u
+        }
+
+        const playerActionRows: APIActionRowComponent<APITextInputComponent>[] = uniquePlayers
+            .map(username => ({
+                components: [{
+                    custom_id: username,
+                    label: `Score for ${username}`,
+                    max_length: 8,
+                    placeholder: `Enter score for ${username} here!`,
+                    required: true,
+                    style: TextInputStyle.Short,
+                    type: ComponentType.TextInput
+                }],
+                type: ComponentType.ActionRow
+            }))
+        const modal: APIModalInteractionResponseCallbackData = {
+            components: [
+                ...playerActionRows,
+                {
+                    components: [
+                        {
+                            custom_id: 'leftover-points',
+                            label: 'Leftover points',
+                            max_length: 8,
+                            required: false,
+                            style: TextInputStyle.Short,
+                            type: ComponentType.TextInput
+                        }
+                    ],
+                    type: ComponentType.ActionRow
+                }
+            ],
+            custom_id: `addscore:${location}:${type}`,
+            title: `Record ${type.toLowerCase()} at ${location.charAt(0).toUpperCase()}${location.slice(1).toLowerCase()}`
+        }
+
+        await interaction.replyWithModal(modal)
+    }
+}

--- a/src/interactions/command/index.ts
+++ b/src/interactions/command/index.ts
@@ -1,0 +1,1 @@
+export * from './addscore.js'

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,0 +1,4 @@
+import type { ChatInputCommand, Modal } from '#types/interaction'
+
+export const commands: Map<string, ChatInputCommand> = new Map([])
+export const modals: Map<string, Modal> = new Map([])

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,4 +1,10 @@
 import type { ChatInputCommand, Modal } from '#types/interaction'
+import { AddScoreCommand } from './command/index.js'
+import { AddScoreModal } from './modal/index.js'
 
-export const commands: Map<string, ChatInputCommand> = new Map([])
-export const modals: Map<string, Modal> = new Map([])
+export const commands: Map<string, ChatInputCommand> = new Map([
+    ['addscore', AddScoreCommand]
+])
+export const modals: Map<string, Modal> = new Map([
+    ['addscore', AddScoreModal]
+])

--- a/src/interactions/modal/addscore.ts
+++ b/src/interactions/modal/addscore.ts
@@ -1,0 +1,88 @@
+import type { ModalInteraction, ToribotClient } from '#structs'
+import type { Modal } from '#types/interaction'
+import type { APIEmbed } from '@discordjs/core'
+import type { GameLocation, GameType } from '@prisma/client'
+
+export const AddScoreModal: Modal = {
+    async handle(client: ToribotClient, interaction: ModalInteraction): Promise<void> {
+        await interaction.defer()
+
+        let embed: Partial<APIEmbed> = { color: 0xF8F8FF }
+
+        const values = interaction.values()
+        const usernames: string[] = [interaction.username]
+        const scores: number[] = []
+
+        let totalScore = 0
+
+        for (const [index, [username, submittedScore]] of values.entries()) {
+            if ((index === 4) && !submittedScore?.length) {
+                scores.push(0)
+                continue
+            }
+
+            const prefix = (index === 4)
+                ? 'The leftover points'
+                : `The score for ${username}`
+
+            if (!/^((0|-?100,?000|-?([1-9]|[1-9]\d?,?\d)00)|(-?(0?\.[1-9]|100(\.0)?|([1-9]\d?(\.\d)?))k?))$/g.test(submittedScore)) {
+                embed.description = `${prefix} is in an invalid format.`
+
+                await interaction.updateReply({ embeds: [embed] })
+                return
+            }
+
+            if (index !== 4)
+                usernames.push(username)
+
+            const score = Number(submittedScore.replace(/[^0-9.]/g, '')) * 1_000
+
+            scores.push(score)
+            totalScore += score
+
+            if (totalScore > 100_000) {
+                embed.description = 'The total score exceeds 100,000 points. Please ensure that all scores sum to a maximum of 100,000 points.'
+
+                await interaction.updateReply({ embeds: [embed] })
+                return
+            }
+        }
+
+        const [, location, type] = interaction.data.custom_id.split(':')
+        const gameId = await client.database.games.insertGame(
+            usernames[0],
+            usernames[1],
+            usernames[2],
+            usernames[3],
+            usernames[4],
+            scores[0],
+            scores[1],
+            scores[2],
+            scores[3],
+            scores[4],
+            location as GameLocation,
+            type as GameType
+        )
+
+        embed = {
+            ...embed,
+            description: [0, 1, 2, 3]
+                .map(index => {
+                    const username = usernames[index + 1]
+                    const cachedPlayer = client.cache.players.get(username)
+
+                    return { score: scores[index], username: Boolean(cachedPlayer) ? `<@${cachedPlayer.toString()}>` : username }
+                })
+                .sort((a, b) => b.score - a.score)
+                .map(({ score, username }) => `${username} - ${score}`)
+                .join('\n'),
+            fields: scores[4]
+                ? [{ inline: false, name: 'Leftover points', value: scores[4].toString() }]
+                : undefined,
+            footer: { text: `Submitted by ${interaction.username}` },
+            title: `Game #${gameId} (${type.toLowerCase()} at ${location.charAt(0).toUpperCase()}${location.slice(1).toLowerCase()})`
+        }
+
+        await interaction.updateReply({ embeds: [embed] })
+    }
+}

--- a/src/interactions/modal/index.ts
+++ b/src/interactions/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './addscore.js'

--- a/src/structs/ToribotClient.ts
+++ b/src/structs/ToribotClient.ts
@@ -1,3 +1,4 @@
+import { Cache, Database } from '#structs'
 import { BOT_TOKEN } from '#utility'
 import { Client, GatewayIntentBits } from '@discordjs/core'
 import { REST } from '@discordjs/rest'
@@ -11,8 +12,14 @@ const gateway = new WebSocketManager({
 })
 
 export class ToribotClient extends Client {
+    readonly cache: Cache
+    readonly database: Database
+
     public constructor() {
         super({ rest, gateway })
+
+        this.cache = new Cache()
+        this.database = new Database()
     }
 
     public async login() {

--- a/src/structs/ToribotClient.ts
+++ b/src/structs/ToribotClient.ts
@@ -15,14 +15,14 @@ export class ToribotClient extends Client {
     readonly cache: Cache
     readonly database: Database
 
-    public constructor() {
+    constructor() {
         super({ rest, gateway })
 
         this.cache = new Cache()
         this.database = new Database()
     }
 
-    public async login() {
+    async login() {
         await gateway.connect()
     }
 }

--- a/src/structs/cache/PlayerCache.ts
+++ b/src/structs/cache/PlayerCache.ts
@@ -1,0 +1,19 @@
+export class PlayerCache {
+    #items: Map<string, bigint | null> = new Map()
+
+    entries() {
+        return this.#items.entries()
+    }
+
+    get(username: string): bigint | null {
+        return this.#items.get(username) ?? null
+    }
+
+    insert(username: string, userId?: bigint) {
+        this.#items.set(username, userId ?? null)
+    }
+
+    remove(username: string) {
+        this.#items.delete(username)
+    }
+}

--- a/src/structs/cache/index.ts
+++ b/src/structs/cache/index.ts
@@ -1,0 +1,5 @@
+import { PlayerCache } from './PlayerCache.js'
+
+export class Cache {
+    readonly players = new PlayerCache()
+}

--- a/src/structs/cache/index.ts
+++ b/src/structs/cache/index.ts
@@ -1,5 +1,9 @@
 import { PlayerCache } from './PlayerCache.js'
 
 export class Cache {
-    readonly players = new PlayerCache()
+    readonly players: PlayerCache
+
+    constructor() {
+        this.players = new PlayerCache()
+    }
 }

--- a/src/structs/client.ts
+++ b/src/structs/client.ts
@@ -1,0 +1,21 @@
+import { BOT_TOKEN } from '#utility'
+import { Client, GatewayIntentBits } from '@discordjs/core'
+import { REST } from '@discordjs/rest'
+import { WebSocketManager } from '@discordjs/ws'
+
+const rest = new REST({ version: '10' }).setToken(BOT_TOKEN)
+const gateway = new WebSocketManager({
+	token: BOT_TOKEN,
+	intents: GatewayIntentBits.Guilds,
+	rest,
+})
+
+export class ToribotClient extends Client {
+    public constructor() {
+        super({ rest, gateway })
+    }
+
+    public async login() {
+        await gateway.connect()
+    }
+}

--- a/src/structs/database/GameTable.ts
+++ b/src/structs/database/GameTable.ts
@@ -1,0 +1,47 @@
+import type {
+    GameLocation,
+    GameType,
+    PrismaClient
+} from '@prisma/client'
+
+export class GameTable {
+    #prisma: PrismaClient
+
+    public constructor(prisma: PrismaClient) {
+        this.#prisma = prisma
+    }
+
+    async insertGame(
+        submitter: string,
+        playerOne: string,
+        playerTwo: string,
+        playerThree: string,
+        playerFour: string,
+        playerOneScore: number,
+        playerTwoScore: number,
+        playerThreeScore: number,
+        playerFourScore: number,
+        leftoverPoints: number,
+        location: GameLocation,
+        type: GameType,
+    ): Promise<number> {
+        const row = await this.#prisma.game.create({
+            data: {
+               submitter,
+               playerOne,
+               playerTwo,
+               playerThree,
+               playerFour,
+               playerOneScore,
+               playerTwoScore,
+               playerThreeScore,
+               playerFourScore,
+               leftoverPoints,
+               location,
+               type,
+            }
+        })
+
+        return row.id
+    }
+}

--- a/src/structs/database/GameTable.ts
+++ b/src/structs/database/GameTable.ts
@@ -7,7 +7,7 @@ import type {
 export class GameTable {
     #prisma: PrismaClient
 
-    public constructor(prisma: PrismaClient) {
+    constructor(prisma: PrismaClient) {
         this.#prisma = prisma
     }
 

--- a/src/structs/database/PlayerTable.ts
+++ b/src/structs/database/PlayerTable.ts
@@ -3,7 +3,7 @@ import type { Player, PrismaClient } from '@prisma/client'
 export class PlayerTable {
     #prisma: PrismaClient
 
-    public constructor(prisma: PrismaClient) {
+    constructor(prisma: PrismaClient) {
         this.#prisma = prisma
     }
 

--- a/src/structs/database/PlayerTable.ts
+++ b/src/structs/database/PlayerTable.ts
@@ -1,0 +1,33 @@
+import type { Player, PrismaClient } from '@prisma/client'
+
+export class PlayerTable {
+    #prisma: PrismaClient
+
+    public constructor(prisma: PrismaClient) {
+        this.#prisma = prisma
+    }
+
+    async insertPlayer(
+        username: string,
+        userId?: bigint
+    ): Promise<void> {
+        await this.#prisma.$executeRawUnsafe(
+            `
+                INSERT INTO
+                    public.player
+                VALUES
+                    ($1, $2)
+                ON CONFLICT (username)
+                DO NOTHING;
+            `,
+            username,
+            userId
+        )
+    }
+
+    async getPlayers(): Promise<Player[]> {
+        const players = await this.#prisma.player.findMany()
+
+        return players
+    }
+}

--- a/src/structs/database/index.ts
+++ b/src/structs/database/index.ts
@@ -1,0 +1,10 @@
+import { GameTable } from './GameTable.js'
+import { PlayerTable } from './PlayerTable.js'
+import { PrismaClient } from '@prisma/client'
+
+export class Database {
+    #prisma = new PrismaClient()
+
+    readonly games = new GameTable(this.#prisma)
+    readonly players = new PlayerTable(this.#prisma)
+}

--- a/src/structs/index.ts
+++ b/src/structs/index.ts
@@ -1,2 +1,4 @@
-export * from './client.js'
+export * from './ToribotClient.js'
+export * from './cache/index.js'
+export * from './database/index.js'
 export * from './interaction/index.js'

--- a/src/structs/index.ts
+++ b/src/structs/index.ts
@@ -1,0 +1,2 @@
+export * from './client.js'
+export * from './interaction/index.js'

--- a/src/structs/interaction/BaseInteraction.ts
+++ b/src/structs/interaction/BaseInteraction.ts
@@ -9,21 +9,33 @@ import {
 import type { REST } from '@discordjs/rest'
 
 export class BaseInteraction {
-    protected readonly applicationId: string
-    readonly id: string
-    protected readonly rest: REST
-    protected readonly token: string
+    #applicationId: string
+    #id: string
+    #rest: REST
+    #token: string
 
-    public constructor({ applicationId, id, rest, token }: BaseInteractionOptions) {
-        this.applicationId = applicationId
-        this.id = id
-        this.rest = rest
-        this.token = token
+    constructor({ applicationId, id, rest, token }: BaseInteractionOptions) {
+        this.#applicationId = applicationId
+        this.#id = id
+        this.#rest = rest
+        this.#token = token
     }
 
-    public async defer({ ephemeral }: { ephemeral?: boolean } = { ephemeral: false }): Promise<void> {
-        await this.rest.post(
-            Routes.interactionCallback(this.id, this.token),
+    get id() {
+        return this.#id
+    }
+
+    get rest() {
+        return this.#rest
+    }
+
+    get token() {
+        return this.#token
+    }
+
+    async defer({ ephemeral }: { ephemeral?: boolean } = { ephemeral: false }): Promise<void> {
+        await this.#rest.post(
+            Routes.interactionCallback(this.#id, this.#token),
             {
                 auth: false,
                 body: {
@@ -36,9 +48,9 @@ export class BaseInteraction {
         )
     }
 
-    public async reply({ ...data }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
-        await this.rest.post(
-            Routes.interactionCallback(this.id, this.token),
+    async reply({ ...data }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
+        await this.#rest.post(
+            Routes.interactionCallback(this.#id, this.#token),
             {
                 auth: false,
                 body: {
@@ -49,16 +61,19 @@ export class BaseInteraction {
         )
     }
 
-    public async response(): Promise<APIMessage> {
-        const message = await this.rest.get(Routes.webhookMessage(this.applicationId, this.token)) as APIMessage
+    async response(): Promise<APIMessage> {
+        const message = await this.#rest.get(Routes.webhookMessage(this.#applicationId, this.#token)) as APIMessage
 
         return message
     }
 
-    public async updateReply({ ...body }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
-        await this.rest.patch(
-            Routes.webhookMessage(this.applicationId, this.token),
-            { auth: false, body }
+    async updateReply({ ...body }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
+        await this.#rest.patch(
+            Routes.webhookMessage(this.#applicationId, this.#token),
+            {
+                auth: false,
+                body
+            }
         )
     }
 }

--- a/src/structs/interaction/BaseInteraction.ts
+++ b/src/structs/interaction/BaseInteraction.ts
@@ -55,19 +55,6 @@ export class BaseInteraction {
         return message
     }
 
-    public async updateMessage({ ...data }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
-        await this.rest.post(
-            Routes.interactionCallback(this.id, this.token),
-            {
-                auth: false,
-                body: {
-                    data,
-                    type: InteractionResponseType.UpdateMessage
-                }
-            }
-        )
-    }
-
     public async updateReply({ ...body }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
         await this.rest.patch(
             Routes.webhookMessage(this.applicationId, this.token),

--- a/src/structs/interaction/BaseInteraction.ts
+++ b/src/structs/interaction/BaseInteraction.ts
@@ -1,0 +1,77 @@
+import type { BaseInteractionOptions } from '#types/interaction'
+import {
+    type APIMessage,
+    type APIInteractionResponseCallbackData,
+    InteractionResponseType,
+    MessageFlags,
+    Routes
+} from '@discordjs/core'
+import type { REST } from '@discordjs/rest'
+
+export class BaseInteraction {
+    protected readonly applicationId: string
+    readonly id: string
+    protected readonly rest: REST
+    protected readonly token: string
+
+    public constructor({ applicationId, id, rest, token }: BaseInteractionOptions) {
+        this.applicationId = applicationId
+        this.id = id
+        this.rest = rest
+        this.token = token
+    }
+
+    public async defer({ ephemeral }: { ephemeral?: boolean } = { ephemeral: false }): Promise<void> {
+        await this.rest.post(
+            Routes.interactionCallback(this.id, this.token),
+            {
+                auth: false,
+                body: {
+                    data: {
+                        flags: ephemeral ? MessageFlags.Ephemeral : undefined
+                    },
+                    type: InteractionResponseType.DeferredChannelMessageWithSource
+                }
+            }
+        )
+    }
+
+    public async reply({ ...data }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
+        await this.rest.post(
+            Routes.interactionCallback(this.id, this.token),
+            {
+                auth: false,
+                body: {
+                    data,
+                    type: InteractionResponseType.ChannelMessageWithSource
+                }
+            }
+        )
+    }
+
+    public async response(): Promise<APIMessage> {
+        const message = await this.rest.get(Routes.webhookMessage(this.applicationId, this.token)) as APIMessage
+
+        return message
+    }
+
+    public async updateMessage({ ...data }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
+        await this.rest.post(
+            Routes.interactionCallback(this.id, this.token),
+            {
+                auth: false,
+                body: {
+                    data,
+                    type: InteractionResponseType.UpdateMessage
+                }
+            }
+        )
+    }
+
+    public async updateReply({ ...body }: Pick<APIInteractionResponseCallbackData, 'content' | 'components' | 'embeds' | 'flags'> = {}): Promise<void> {
+        await this.rest.patch(
+            Routes.webhookMessage(this.applicationId, this.token),
+            { auth: false, body }
+        )
+    }
+}

--- a/src/structs/interaction/ChatInputCommandInteraction.ts
+++ b/src/structs/interaction/ChatInputCommandInteraction.ts
@@ -1,3 +1,4 @@
+import { BaseInteraction } from '#structs'
 import type { AutocompleteFocusedOption, ChatInputCommandInteractionOptions } from '#types/interaction'
 import {
     type APIApplicationCommandOptionChoice,
@@ -6,22 +7,31 @@ import {
     InteractionResponseType,
     Routes
 } from '@discordjs/core'
-import { BaseInteraction } from './BaseInteraction.js'
 
 export class ChatInputCommandInteraction extends BaseInteraction {
-    readonly data: APIChatInputApplicationCommandInteractionData
-    readonly guildId: string
-    readonly username: string
+    #data: APIChatInputApplicationCommandInteractionData
+    #guildId: string
 
-    public constructor({ data, guildId, username, ...baseOptions }: ChatInputCommandInteractionOptions) {
-        super(baseOptions)
+    constructor(options: ChatInputCommandInteractionOptions) {
+        super(options)
 
-        this.data = data
-        this.guildId = guildId
-        this.username = username
+        this.#data = options.data
+        this.#guildId = options.guildId
     }
 
-    public async autocomplete(choices: APIApplicationCommandOptionChoice<number | string>[]): Promise<void> {
+    get guildId() {
+        return this.#guildId
+    }
+
+    get name() {
+        return this.#data.name
+    }
+
+    get options() {
+        return this.#data.options
+    }
+
+    async autocomplete(choices: APIApplicationCommandOptionChoice<number | string>[]): Promise<void> {
         await this.rest.post(
             Routes.interactionCallback(this.id, this.token),
             {
@@ -36,13 +46,13 @@ export class ChatInputCommandInteraction extends BaseInteraction {
         )
     }
 
-    public getFocusedOption<T extends AutocompleteFocusedOption>(): T {
-        const option = this.data.options.find(o => ('focused' in o) && Boolean(o.focused)) as T
+    getFocusedOption<T extends AutocompleteFocusedOption>(): T {
+        const option = this.#data.options.find(o => ('focused' in o) && Boolean(o.focused)) as T
 
         return option
     }
 
-    public async replyWithModal(data: APIModalInteractionResponseCallbackData): Promise<void> {
+    async replyWithModal(data: APIModalInteractionResponseCallbackData): Promise<void> {
         await this.rest.post(
             Routes.interactionCallback(this.id, this.token),
             {

--- a/src/structs/interaction/ChatInputCommandInteraction.ts
+++ b/src/structs/interaction/ChatInputCommandInteraction.ts
@@ -10,12 +10,14 @@ import { BaseInteraction } from './BaseInteraction.js'
 
 export class ChatInputCommandInteraction extends BaseInteraction {
     readonly data: APIChatInputApplicationCommandInteractionData
+    readonly guildId: string
     readonly username: string
 
-    public constructor({ data, username, ...baseOptions }: ChatInputCommandInteractionOptions) {
+    public constructor({ data, guildId, username, ...baseOptions }: ChatInputCommandInteractionOptions) {
         super(baseOptions)
 
         this.data = data
+        this.guildId = guildId
         this.username = username
     }
 

--- a/src/structs/interaction/ChatInputCommandInteraction.ts
+++ b/src/structs/interaction/ChatInputCommandInteraction.ts
@@ -1,0 +1,55 @@
+import type { AutocompleteFocusedOption, ChatInputCommandInteractionOptions } from '#types/interaction'
+import {
+    type APIApplicationCommandOptionChoice,
+    type APIChatInputApplicationCommandInteractionData,
+    type APIModalInteractionResponseCallbackData,
+    InteractionResponseType,
+    Routes
+} from '@discordjs/core'
+import { BaseInteraction } from './BaseInteraction.js'
+
+export class ChatInputCommandInteraction extends BaseInteraction {
+    readonly data: APIChatInputApplicationCommandInteractionData
+    readonly username: string
+
+    public constructor({ data, username, ...baseOptions }: ChatInputCommandInteractionOptions) {
+        super(baseOptions)
+
+        this.data = data
+        this.username = username
+    }
+
+    public async autocomplete(choices: APIApplicationCommandOptionChoice<number | string>[]): Promise<void> {
+        await this.rest.post(
+            Routes.interactionCallback(this.id, this.token),
+            {
+                auth: false,
+                body: {
+                    data: {
+                        choices
+                    },
+                    type: InteractionResponseType.ApplicationCommandAutocompleteResult
+                }
+            }
+        )
+    }
+
+    public getFocusedOption<T extends AutocompleteFocusedOption>(): T {
+        const option = this.data.options.find(o => ('focused' in o) && Boolean(o.focused)) as T
+
+        return option
+    }
+
+    public async replyWithModal(data: APIModalInteractionResponseCallbackData): Promise<void> {
+        await this.rest.post(
+            Routes.interactionCallback(this.id, this.token),
+            {
+                auth: false,
+                body: {
+                    data,
+                    type: InteractionResponseType.Modal
+                }
+            }
+        )
+    }
+}

--- a/src/structs/interaction/ModalInteraction.ts
+++ b/src/structs/interaction/ModalInteraction.ts
@@ -1,0 +1,25 @@
+import type { ModalInteractionOptions } from '#types/interaction'
+import { BaseInteraction } from './BaseInteraction.js'
+import type { APIModalSubmission } from '@discordjs/core'
+
+export class ModalInteraction extends BaseInteraction {
+    readonly data: APIModalSubmission
+    readonly username: string
+
+    public constructor({ data, username, ...baseOptions }: ModalInteractionOptions) {
+        super(baseOptions)
+
+        this.data = data
+        this.username = username
+    }
+
+    public values(): [string, string][] {
+        const entries = this.data.components.map(component => {
+            const { custom_id, value } = component.components[0]
+
+            return [custom_id, value] as [string, string]
+        })
+
+        return entries
+    }
+}

--- a/src/structs/interaction/ModalInteraction.ts
+++ b/src/structs/interaction/ModalInteraction.ts
@@ -3,18 +3,26 @@ import { BaseInteraction } from './BaseInteraction.js'
 import type { APIModalSubmission } from '@discordjs/core'
 
 export class ModalInteraction extends BaseInteraction {
-    readonly data: APIModalSubmission
-    readonly username: string
+    #data: APIModalSubmission
+    #username: string
 
-    public constructor({ data, username, ...baseOptions }: ModalInteractionOptions) {
-        super(baseOptions)
+    constructor(options: ModalInteractionOptions) {
+        super(options)
 
-        this.data = data
-        this.username = username
+        this.#data = options.data
+        this.#username = options.username
     }
 
-    public values(): [string, string][] {
-        const entries = this.data.components.map(component => {
+    get customId() {
+        return this.#data.custom_id
+    }
+
+    get username() {
+        return this.#username
+    }
+
+    values(): [string, string][] {
+        const entries = this.#data.components.map(component => {
             const { custom_id, value } = component.components[0]
 
             return [custom_id, value] as [string, string]

--- a/src/structs/interaction/index.ts
+++ b/src/structs/interaction/index.ts
@@ -1,0 +1,3 @@
+export * from './BaseInteraction.js'
+export * from './ChatInputCommandInteraction.js'
+export * from './ModalInteraction.js'

--- a/src/types/interaction.d.ts
+++ b/src/types/interaction.d.ts
@@ -1,15 +1,15 @@
 import type {
     ChatInputCommandInteraction,
-    ModalSubmitInteraction,
-    ToribotClient,
+    ModalInteraction,
+    ToribotClient
 } from '#structs'
 import type {
     APIApplicationCommandInteractionDataIntegerOption,
     APIApplicationCommandInteractionDataNumberOption,
     APIApplicationCommandInteractionDataStringOption,
+    APIApplicationCommandOption,
     APIChatInputApplicationCommandInteractionData,
     APIModalSubmission,
-    ModalSubmitInteraction
 } from '@discordjs/core'
 import type { REST } from '@discordjs/rest'
 
@@ -18,27 +18,28 @@ export type AutocompleteFocusedOption =
     | APIApplicationCommandInteractionDataNumberOption
     | APIApplicationCommandInteractionDataStringOption
 
-export type BaseInteractionOptions = {
-    applicationId: string,
-    id: string,
-    rest: REST,
+export interface BaseInteractionOptions {
+    applicationId: string
+    id: string
+    rest: REST
     token: string
 }
 
 export interface ChatInputCommand {
-    getCommand(): RESTPostAPIApplicationCommandsJSONBody
+    getCommand(): APIApplicationCommandOption | RESTPostAPIApplicationCommandsJSONBody
     run(client: ToribotClient, interaction: ChatInputCommandInteraction): Promise<void>
 }
 
-export type ChatInputCommandInteractionOptions = WithBaseInteractionOptions<APIChatInputApplicationCommandInteractionData> & { guildId: string }
-
-export interface Modal {
-    handle(client: ToribotClient, interaction: ModalSubmitInteraction): Promise<void>
+export interface ChatInputCommandInteractionOptions extends BaseInteractionOptions {
+    data: APIChatInputApplicationCommandInteractionData
+    guildId: string
 }
 
-export type ModalInteractionOptions = WithBaseInteractionOptions<APIModalSubmission>
+export interface Modal {
+    run(client: ToribotClient, interaction: ModalInteraction): Promise<void>
+}
 
-export interface WithBaseInteractionOptions<T extends APIChatInputApplicationCommandInteractionData | APIModalSubmission> extends BaseInteractionOptions {
-    data: T,
+export interface ModalInteractionOptions extends BaseInteractionOptions {
+    data: APIModalSubmission
     username: string
 }

--- a/src/types/interaction.d.ts
+++ b/src/types/interaction.d.ts
@@ -30,7 +30,7 @@ export interface ChatInputCommand {
     run(client: ToribotClient, interaction: ChatInputCommandInteraction): Promise<void>
 }
 
-export type ChatInputCommandInteractionOptions = WithBaseInteractionOptions<APIChatInputApplicationCommandInteractionData>
+export type ChatInputCommandInteractionOptions = WithBaseInteractionOptions<APIChatInputApplicationCommandInteractionData> & { guildId: string }
 
 export interface Modal {
     handle(client: ToribotClient, interaction: ModalSubmitInteraction): Promise<void>

--- a/src/types/interaction.d.ts
+++ b/src/types/interaction.d.ts
@@ -1,0 +1,44 @@
+import type {
+    ChatInputCommandInteraction,
+    ModalSubmitInteraction,
+    ToribotClient,
+} from '#structs'
+import type {
+    APIApplicationCommandInteractionDataIntegerOption,
+    APIApplicationCommandInteractionDataNumberOption,
+    APIApplicationCommandInteractionDataStringOption,
+    APIChatInputApplicationCommandInteractionData,
+    APIModalSubmission,
+    ModalSubmitInteraction
+} from '@discordjs/core'
+import type { REST } from '@discordjs/rest'
+
+export type AutocompleteFocusedOption =
+    | APIApplicationCommandInteractionDataIntegerOption
+    | APIApplicationCommandInteractionDataNumberOption
+    | APIApplicationCommandInteractionDataStringOption
+
+export type BaseInteractionOptions = {
+    applicationId: string,
+    id: string,
+    rest: REST,
+    token: string
+}
+
+export interface ChatInputCommand {
+    getCommand(): RESTPostAPIApplicationCommandsJSONBody
+    run(client: ToribotClient, interaction: ChatInputCommandInteraction): Promise<void>
+}
+
+export type ChatInputCommandInteractionOptions = WithBaseInteractionOptions<APIChatInputApplicationCommandInteractionData>
+
+export interface Modal {
+    handle(client: ToribotClient, interaction: ModalSubmitInteraction): Promise<void>
+}
+
+export type ModalInteractionOptions = WithBaseInteractionOptions<APIModalSubmission>
+
+export interface WithBaseInteractionOptions<T extends APIChatInputApplicationCommandInteractionData | APIModalSubmission> extends BaseInteractionOptions {
+    data: T,
+    username: string
+}

--- a/src/utility/constants.ts
+++ b/src/utility/constants.ts
@@ -1,0 +1,1 @@
+export const BOT_TOKEN = process.env.BOT_TOKEN

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -1,0 +1,1 @@
+export * from './constants.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,13 @@
 		"noUnusedLocals": false,
 		"noUnusedParameters": false,
         "outDir": "dist",
+        "paths": {
+            "#events": ["./src/events/index"],
+            "#interactions": ["./src/interactions/index"],
+            "#structs": ["./src/structs/index"],
+            "#types/*": ["./src/types/*.d.ts"],
+            "#utility": ["./src/utility/index"]
+        },
 		"preserveConstEnums": true,
 		"pretty": true,
 		"removeComments": false,


### PR DESCRIPTION
This PR has two parts - this adds the command itself and support for interaction handling. 

For interaction handling, the following are supported:

- Autocomplete interactions
- Modal interactions
- Slash command (referred to as "chat input commands" to be specific) interactions

For the command itself, a few notes:

- It is a two-step process, users invoke the command (with all four users) and then enter scores after
- Common score formats are supported; for example:
    - 23.9
    - 23.9k
    - 23,900
- If valid, an embed is shown at the end with the resulting embed.